### PR TITLE
Add files via upload

### DIFF
--- a/Calculus for Machine Learning (Derivatives)/day3_ex1.py
+++ b/Calculus for Machine Learning (Derivatives)/day3_ex1.py
@@ -1,38 +1,11 @@
-"""
-Day 3 Exercise 1 – Symbolic Derivatives and the Chain Rule using SymPy.
-
-Covers:
-  - Basic single-variable derivatives
-  - Product rule and quotient rule
-  - Chain rule for composite functions
-"""
-
 import sympy as sp
 
+# Define a function
 x = sp.Symbol('x')
+f = x**3 - 5*x + 7
 
-# ── Basic Derivative ─────────────────────────────────────────────────────────
-f = x**3 - 5*x**2 + 6*x - 2
-df = sp.diff(f, x)
-print("f(x)  =", f)
-print("f'(x) =", df)
+# Compute Derivative
+derivative = sp.diff(f, x)
 
-# ── Product Rule: d/dx [u(x) * v(x)] = u'v + uv' ────────────────────────────
-u = x**2
-v = sp.sin(x)
-product = u * v
-d_product = sp.diff(product, x)
-print("\nProduct rule: d/dx [x² · sin(x)] =", d_product)
-
-# ── Quotient Rule: d/dx [u/v] = (u'v - uv') / v² ───────────────────────────
-numerator = sp.exp(x)
-denominator = x**2 + 1
-quotient = numerator / denominator
-d_quotient = sp.diff(quotient, x)
-print("\nQuotient rule: d/dx [e^x / (x²+1)] =", sp.simplify(d_quotient))
-
-# ── Chain Rule: d/dx [f(g(x))] = f'(g(x)) · g'(x) ──────────────────────────
-g = x**2 + 1          # inner function
-composite = sp.sin(g)  # outer function applied to g
-d_composite = sp.diff(composite, x)
-print("\nChain rule: d/dx [sin(x²+1)] =", d_composite)
+print("Function: ", f)
+print("Derivative: ", derivative)


### PR DESCRIPTION
This pull request simplifies the `day3_ex1.py` exercise script by removing examples for product, quotient, and chain rules, and focusing solely on computing the basic derivative of a single function. The script now defines a function, computes its derivative, and prints the results.

Basic derivative computation:

* The script now defines `f = x**3 - 5*x + 7` and computes its derivative, removing examples of product, quotient, and chain rule derivatives.
* Output is simplified to show only the function and its derivative.